### PR TITLE
[Bug fix] Do an early return when no cb is provided

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,6 +28,7 @@ function plugin(racer) {
         if (cb) return cb(err);
         else throw new Error(err);
       }
+      if (!cb) return;
 
       args.unshift(null); // no error, everything is ok
 


### PR DESCRIPTION
There is currently a bug when you don't provide a callback function to `.call()`. We don't need to call it if it doesn't exist.